### PR TITLE
fix: allow foo/index to be mapped to foo/index/index.html

### DIFF
--- a/docs/workshops/ci-cd/set-up-ci/00_prerequisites.md
+++ b/docs/workshops/ci-cd/set-up-ci/00_prerequisites.md
@@ -14,4 +14,6 @@ title: Prerequisites
 
 ⚠️ Note: these instructions have been written for, and tested, in a bash shell on Mac. They should work correctly on Linux. If you are using Windows, then you will need to know how to run git/make/node CLI commands, or pair with someone who does.
 
+> If you have access to a second screen, we recommend that you use it for this workshop, as there is a lot of window switching involved.
+
 [travis-ci]: https://travis-ci.com

--- a/docs/workshops/ci-cd/workshop/00_prerequisites.md
+++ b/docs/workshops/ci-cd/workshop/00_prerequisites.md
@@ -6,6 +6,7 @@ title: Prerequisites
 * CI/CD pipelines for the consumer and provider as per the [Setup CI/CD page](/docs/ci-cd-workshop/set-up-ci)
 * A working local development set up as per the [Setup local development](/docs/ci-cd-workshop/set-up-local-development) page.
 * Both consumer and provider builds in Travis CI should both be passing on master.
+* If you have access to a second screen, we recommend that you use it for this workshop, as there is a lot of window switching involved.
 * Suggested window configuration:
     * In [Travis CI][travis-ci]:
         * One tab for the example-consumer build

--- a/website/package.json
+++ b/website/package.json
@@ -3,6 +3,7 @@
     "examples": "docusaurus-examples",
     "start": "docusaurus-start",
     "build": "docusaurus-build",
+    "postbuild": "./scripts/copy-index-pages.sh",
     "write-translations": "docusaurus-write-translations",
     "version": "docusaurus-version",
     "rename-version": "docusaurus-rename-version"

--- a/website/scripts/copy-index-pages.sh
+++ b/website/scripts/copy-index-pages.sh
@@ -1,0 +1,15 @@
+#/!bin/sh
+
+# Work around for https://github.com/pactflow/docs.pactflow.io/issues/8
+
+index_pages=$(find build -name index.html)
+
+for index_page in ${index_pages}; do        # eg. foo/index.html
+  directory=$(dirname "${index_page}")      # eg. foo
+  unclean_page="${directory}.html"          # eg. foo.html
+  if [ ! -f "${unclean_page}" ]; then
+    echo "Copying ${index_page} to ${directory}/index/index.html"
+    mkdir -p "${directory}/index"
+    cp "${index_page}" "${directory}/index" # eg foo/index/index.html
+  fi
+done


### PR DESCRIPTION
Copies `foo/index.html` to `foo/index/index.html` so that the generated `foo/index` link works.

Every .html page is copied to a directory with the same name, and an index page is put within that directory, so that both '/foo' and 'foo.html' work.

For some reason this is explicitly disabled in the generate script, but the URL generation script (which I haven't looked in to) does not take this into account. Rather than hacking the JS, it seemed easiest to just copy the index files to the correct place, the way all the other files are.

Fixes: https://github.com/pactflow/docs.pactflow.io/issues/8