### PR TITLE
chore: update docs for 1.12.0

### DIFF
--- a/website/docs/docs/on-premises/environment-variables.md
+++ b/website/docs/docs/on-premises/environment-variables.md
@@ -245,6 +245,13 @@ Used during SP-initiated SSO. Describes the format of the username required by t
 **Default:** `urn:oasis:names:tc:SAML:2.0:nameid-format:persistent`<br/>
 **Allowed values:** `urn:oasis:names:tc:SAML:2.0:nameid-format:persistent`, `urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress`<br/>
 
+### PACTFLOW_SAML_ALLOWED_CLOCK_DRIFT
+
+To allow for a small amount of clock drift between Pactflow and the Identity Provider, the allowed clock drift may be specified. Its value must be given in a number (and/or fraction) of seconds. The value is added to the current time at which the response is validated, before it is tested against the NotBefore assertion.
+
+**Required:** false<br/>
+**Default:** `0`<br/>
+
 <br/>
 
 ## Basic authentication
@@ -485,4 +492,3 @@ head < /dev/random -c 16 | base64
 **Required:** if `PACTFLOW_API_TOKEN_ENCRYPTION_ENABLED` is set to `true`<br/>
 **Default:** `not set`<br/>
 **Example:** `JUVDdnRzLXZyWHA7UF93RAo=`<br/>
-

--- a/website/docs/docs/on-premises/releases/1.11.1.md
+++ b/website/docs/docs/on-premises/releases/1.11.1.md
@@ -1,5 +1,5 @@
 ---
-title: 1.11.0
+title: 1.11.1
 ---
 
 ## Release date

--- a/website/docs/docs/on-premises/releases/1.12.0.md
+++ b/website/docs/docs/on-premises/releases/1.12.0.md
@@ -1,0 +1,14 @@
+---
+title: 1.12.0
+---
+
+## Release date
+
+21 September 2021
+
+## Features
+
+* Add support for [PACTFLOW_SAML_ALLOWED_CLOCK_DRIFT](/docs/on-premises/environment-variables#pactflow_saml_allowed_clock_drift)
+* Validate encryption master key on startup
+* Allow the default role and team to be configured in the system preferences
+* Add [Guest role](/docs/permissions/predefined-roles#guest).

--- a/website/docs/docs/permissions/predefined-roles.md
+++ b/website/docs/docs/permissions/predefined-roles.md
@@ -25,7 +25,7 @@ The user who signed up for the Pactflow tenant will be assigned the Administrato
 
 ## User
 
-All new users are assigned the `User` role. The `User` role is intended to work in conjunction with [team assignments](/docs/user-interface/settings/teams), and therefore has `manage:team` permissions (rather than `manage:*` permissions) for all resources that can be associated with a team. 
+All new users are assigned the `User` role (unless the default role has been updated in the [system preferences](/docs/user-interface/settings/preferences#system-preferences)). The `User` role is intended to work in conjunction with [team assignments](/docs/user-interface/settings/teams), and therefore has `manage:team` permissions (rather than `manage:*` permissions) for all resources that can be associated with a team. The `User` role should be assigned to all developers, testers and other users who create and verify contracts in the Pactflow platform.
 
 #### Default permissions
 
@@ -67,10 +67,18 @@ This role is automatically assigned to any user who is set as an administrator o
 
 * [`contract_data:read:*`](/docs/permissions/permissions#contract_data-read)
 * [`read_token:manage:own`](/docs/permissions/permissions#read_token-manage-own)
-* [`system_preferences:read:*`](/docs/permissions/permissions#system_preferences-read)
 * [`team:read:*`](/docs/permissions/permissions#team-read)
 * [`user:read:*`](/docs/permissions/permissions#user-read)
 
+## Guest
+
+A user with the guest role can only view contract related data through the UI, and has no API access. For some [Pactflow SaaS plans](https://pactflow.io/pricing/), users with only the guest role are free.
+
+The permissions associated with the guest role may not be modified.
+
+#### Permissions
+
+* [`contract_data:read:*`](/docs/permissions/permissions#contract_data-read)
 
 ## Test Maintainer (deprecated)
 
@@ -85,7 +93,6 @@ The Test Maintainer role has been replaced by the User role. The difference betw
 * [`role:read:*`](/docs/permissions/permissions#role-read)
 * [`secret:manage:*`](/docs/permissions/permissions#secret-manage)
 * [`system_account:read:*`](/docs/permissions/permissions#system_account-read)
-* [`system_preferences:read:*`](/docs/permissions/permissions#system_preferences-read)
 * [`team:read:*`](/docs/permissions/permissions#team-read)
 * [`token:manage:own`](/docs/permissions/permissions#token:manage:own)
 * [`user:read:*`](/docs/permissions/permissions#user-read)

--- a/website/docs/docs/user-interface/settings/preferences.md
+++ b/website/docs/docs/user-interface/settings/preferences.md
@@ -36,3 +36,11 @@ management screen](./users#system-accounts) (for system accounts).
 This setting configures an announcement banner to be displayed to all users when they login. The banner content can contain [Markdown
 formatted text](https://commonmark.org/help/) (which also supports HTML markup). Note that text will be santised in the UI, so you
 can not add any Javascript to the banner.
+
+#### Default Role
+
+The default role to assign new users. If this preference is not set, new users will be assigned the [User](/docs/permissions/predefined-roles#user) role.
+
+#### Default Team
+
+The default team to which new team members will be added. If this preference is not set, new users will be assigned to the system defined team named "[Default team](/docs/user-interface/settings/teams#the-default-team)" if it exists.

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -230,6 +230,7 @@ module.exports = {
           type: "category",
           label: "Releases",
           items: [
+            "docs/on-premises/releases/1.12.0",
             "docs/on-premises/releases/1.11.1",
             "docs/on-premises/releases/1.11.0",
             "docs/on-premises/releases/1.10.0",


### PR DESCRIPTION
Things that are deliberately not released or documented as they're not ready yet, either in terms of the code or the documentation:
* environments - until we get team environments working (the link is hidden though the API is accessible)
* OAuth and OIDC
* Anyway config files