### PR TITLE
chore: allow google to index documentation

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -83,10 +83,7 @@ module.exports = {
     hideableSidebar: true,
     cleanUrl: true,
   },
-  plugins: [
-    path.resolve(__dirname, "src/plugins/plugin-noindex"),
-    path.resolve(__dirname, "src/plugins/plugin-segment"),
-  ],
+  plugins: [path.resolve(__dirname, "src/plugins/plugin-segment")],
   presets: [
     [
       "@docusaurus/preset-classic",


### PR DESCRIPTION
I'm not sure why we ever had this. I definitely added this to our partner docs, I'm wondering if it was copied across during an upgrade or something.

In any case, we definitely want our docs internet searchable. 

I noticed it was the case when I could never search for things I knew only existed in our documentation, and then realised the pages had index exclusions.