### PR TITLE
chore: add docs for known vulnerabilities

### DIFF
--- a/website/docs/docs/on-premises/security-audit-report.md
+++ b/website/docs/docs/on-premises/security-audit-report.md
@@ -1,8 +1,8 @@
 ---
-title: Something
+title: Security audit report
 ---
 
-# Vulnerability scanning
+## Vulnerability scanning
 
 Pactflow uses the following tools to ensure the On-Premises image is kept as secure as possible.
 
@@ -12,13 +12,13 @@ Pactflow uses the following tools to ensure the On-Premises image is kept as sec
 * Quay Security Scanner
 * Amazon ECR Image scanning
 
-# Reporting vulnerabilities
+## Reporting vulnerabilities
 
 To report a vulnerability, please email us at [support@pactflow.io](mailto:support@pactflow.io) and ensure you include the relevant CVE, and the name and/or path to the vulnerable component.
 
-# Known vulnerabilities
+## Known vulnerabilities
 
-## CVE-2015-9284
+### CVE-2015-9284
 
 #### Component
 
@@ -36,7 +36,7 @@ This is a CSRF vulnerability during sign in.
 
 This vulnerability is mitigated in code. Pactflow uses a POST request method with a CSRF token for the initial request to the IDP, as per the instructions [here](https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284).
 
-## CVE-2021-23358
+### CVE-2021-23358
 
 #### Component
 

--- a/website/docs/docs/on-premises/something.md
+++ b/website/docs/docs/on-premises/something.md
@@ -12,6 +12,10 @@ Pactflow uses the following tools to ensure the On-Premises image is kept as sec
 * Quay Security Scanner
 * Amazon ECR Image scanning
 
+# Reporting vulnerabilities
+
+To report a vulnerability, please email us at [support@pactflow.io](mailto:support@pactflow.io) and ensure you include the relevant CVE, and the name and/or path to the vulnerable component.
+
 # Known vulnerabilities
 
 ## CVE-2015-9284
@@ -49,3 +53,5 @@ Underscore is a dependency of the HAL Browser (accessible through the UI by clic
 #### Mitigation
 
 The HAL Browser can be disabled by setting the [environment variable](/docs/on-premises/environment-variables#pactflow_use_hal_browser) `PACTFLOW_USE_HAL_BROWSER=false` 
+
+

--- a/website/docs/docs/on-premises/something.md
+++ b/website/docs/docs/on-premises/something.md
@@ -16,15 +16,36 @@ Pactflow uses the following tools to ensure the On-Premises image is kept as sec
 
 ## CVE-2015-9284
 
-* Component: omniauth
-* More information: [https://nvd.nist.gov/vuln/detail/CVE-2015-9284](https://nvd.nist.gov/vuln/detail/CVE-2015-9284)
+#### Component
 
-This is a CSRF vulnerability during sign in. It is mitigated in Pactflow by using a POST request method with a CSRF token for the initial request to the IDP, as per the instructions [here](https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284).
+omniauth
 
+#### CVE
+
+[https://nvd.nist.gov/vuln/detail/CVE-2015-9284](https://nvd.nist.gov/vuln/detail/CVE-2015-9284)
+
+#### Notes
+
+This is a CSRF vulnerability during sign in. 
+
+#### Mitigation
+
+This vulnerability is mitigated in code. Pactflow uses a POST request method with a CSRF token for the initial request to the IDP, as per the instructions [here](https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284).
 
 ## CVE-2021-23358
 
-* Component: underscore
-* More information: [https://nvd.nist.gov/vuln/detail/CVE-2021-23358](https://nvd.nist.gov/vuln/detail/CVE-2021-23358)
+#### Component
 
-Underscore is a dependency of the HAL Browser (accessible through the UI by clicking the "API Browser" button), which is not currently maintained. The HAL Browser can be disabled by setting the [environment variable](/docs/on-premises/environment-variables#pactflow_use_hal_browser) `PACTFLOW_USE_HAL_BROWSER=false` 
+underscore
+
+#### CVE
+
+[https://nvd.nist.gov/vuln/detail/CVE-2021-23358](https://nvd.nist.gov/vuln/detail/CVE-2021-23358)
+
+#### Notes
+
+Underscore is a dependency of the HAL Browser (accessible through the UI by clicking the "API Browser" button), which is not currently maintained. The Underscore version used is vulnerable to Arbitrary Code Injection via the template function.
+
+#### Mitigation
+
+The HAL Browser can be disabled by setting the [environment variable](/docs/on-premises/environment-variables#pactflow_use_hal_browser) `PACTFLOW_USE_HAL_BROWSER=false` 

--- a/website/docs/docs/on-premises/something.md
+++ b/website/docs/docs/on-premises/something.md
@@ -1,0 +1,30 @@
+---
+title: Something
+---
+
+# Vulnerability scanning
+
+Pactflow uses the following tools to ensure the On-Premises image is kept as secure as possible.
+
+* Bundler Audit
+* NPM audit
+* Trivy
+* Quay Security Scanner
+* Amazon ECR Image scanning
+
+# Known vulnerabilities
+
+## CVE-2015-9284
+
+* Component: omniauth
+* More information: [https://nvd.nist.gov/vuln/detail/CVE-2015-9284](https://nvd.nist.gov/vuln/detail/CVE-2015-9284)
+
+This is a CSRF vulnerability during sign in. It is mitigated in Pactflow by using a POST request method with a CSRF token for the initial request to the IDP, as per the instructions [here](https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284).
+
+
+## CVE-2021-23358
+
+* Component: underscore
+* More information: [https://nvd.nist.gov/vuln/detail/CVE-2021-23358](https://nvd.nist.gov/vuln/detail/CVE-2021-23358)
+
+Underscore is a dependency of the HAL Browser (accessible through the UI by clicking the "API Browser" button), which is not currently maintained. The HAL Browser can be disabled by setting the [environment variable](/docs/on-premises/environment-variables#pactflow_use_hal_browser) `PACTFLOW_USE_HAL_BROWSER=false` 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -224,6 +224,11 @@ module.exports = {
         },
         {
           type: "category",
+          label: "Something",
+          items: ["docs/on-premises/something"],
+        },
+        {
+          type: "category",
           label: "Troubleshooting",
           items: ["docs/on-premises/troubleshooting"],
         },

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -224,8 +224,8 @@ module.exports = {
         },
         {
           type: "category",
-          label: "Something",
-          items: ["docs/on-premises/something"],
+          label: "Security and support",
+          items: ["docs/on-premises/security-audit-report"],
         },
         {
           type: "category",


### PR DESCRIPTION
So we don't have to repeat ourselves each time, we should have a page that lists our known vulnerabilities and their mitigations. I'm definitely missing some for bootstrap, but I'll add them as they come up. The most recent people who complained about them didn't include the CVEs.

* What should the page be called?
* Any extra info?