### PR TITLE
docs: remove edit this link from view to users

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -97,9 +97,6 @@ module.exports = {
           blogTitle: "Pactflow Updates",
           blogDescription:
             "Updates on the Pactflow platform, including security notices and new on-premises releases",
-          // Please change this to your repo.
-          editUrl:
-            "https://github.com/pactflow/docs.pactflow.io/edit/master/website/blog/",
           feedOptions: {
             type: "all",
             copyright: `Copyright © ${new Date().getFullYear()} DiUS Computing Pty. Ltd.`,


### PR DESCRIPTION
on our pactflow docs page, regular users can't edit the docs pages as the docs are private, so they get a 404. 

We can disable by removing the editUrl property as per docusaurus [docs](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-docs#editUrl)

Note this would be a bit of an inconvenience to Pactflow doc maintainers, and we may want consider additional messaging for users, if they want to suggest a change to the docs