### PR TITLE
Faq

### DIFF
--- a/website/docs/docs/bi-directional-contract-testing/compatibility-checks.md
+++ b/website/docs/docs/bi-directional-contract-testing/compatibility-checks.md
@@ -26,7 +26,7 @@ This tab will display the details of the comparison between the Pact file and th
 
 ## Contract Incompatibility Messages
 
-| Error Messsage | Description |
+| Error Message | Description |
 | ---------- | ----------- |
 | Request accept header is incompatible | Pact request's accept header content is incompatible with provider contract |
 | Request misses authorization header | Pact request's authorization header is missing |
@@ -38,4 +38,4 @@ This tab will display the details of the comparison between the Pact file and th
 | Response body is incompatible | Pact response's body content is incompatible with provider contract |
 | Response body contains unknown information | Pact response's body contains unknown content compared with provider contract|
 | Response request is incompatible | Pact response's request content is incompatible with provider contract|
-| Reponse header contains unknown information | Pact response's header contains unknown content compared with provider contract |
+| Response header contains unknown information | Pact response's header contains unknown content compared with provider contract |

--- a/website/docs/docs/bi-directional-contract-testing/consumer.md
+++ b/website/docs/docs/bi-directional-contract-testing/consumer.md
@@ -71,7 +71,7 @@ A simplified view of a CI/CD pipeline for Pact looks like this:
 
 ![Consumer Pipeline](/workshops/bi-directional/3-bi-directional-consumer-pipeline-deployed.png "Consumer Pipeline")
 
-The standard [principles](https://docs.pact.io/pact_nirvana) are still relevent. Our [CI/CD workshop](/docs/workshops/ci-cd) is a useful reference (NOTE: the CI/CD workshop uses the consumer-driven mode using Pact).
+The standard [principles](https://docs.pact.io/pact_nirvana) are still relevant. Our [CI/CD workshop](/docs/workshops/ci-cd) is a useful reference (NOTE: the CI/CD workshop uses the consumer-driven mode using Pact).
 
 ## Community Adapters
 

--- a/website/docs/docs/faq.md
+++ b/website/docs/docs/faq.md
@@ -13,6 +13,8 @@ title: Frequently asked questions
 
 ## Roadmap
 
+<!-- Part of this information is taken from https://pactflow.io/pactflow-feature-roadmap -->
+
 This is a high level view of our product road-map. 
 
 Don’t like the order or want to see something else here? You can change that by voting or asking for a feature:

--- a/website/docs/docs/faq.md
+++ b/website/docs/docs/faq.md
@@ -13,6 +13,21 @@ title: Frequently asked questions
 
 ## Roadmap
 
+This is a high level view of our product road-map. 
+
+Don’t like the order or want to see something else here? You can change that by voting or asking for a feature:
+
+[Open Source Roadmap]: https://pact.canny.io/
+[Open Source Feature Requests]: https://pact.canny.io/feature-requests
+[Pactflow Roadmap]: https://github.com/pactflow/roadmap/projects/1
+[Pactflow Issues]: https://github.com/pactflow/roadmap/issues/new
+
+If you aren't able to do this publicly, please contact us at hello@pactflow.io and we'd be happy to chat.
+
+All of our upcoming work flows through the following five stages: 
+
+Backlog -> Analysis -> Planned Work -> In-Progress -> Released.
+
 ## Raising issues
 
 * How to raise tickets with priority/customers attached

--- a/website/docs/docs/user-interface/bi-directional.md
+++ b/website/docs/docs/user-interface/bi-directional.md
@@ -26,6 +26,17 @@ Bi-Directional Contract Testing results are listed one the overview tab.
 
 </div>
 
+
+:::info we are working hard to improve this view even further.
+Currently this page supports showing one verification per consumer version, whichever provider version was most recently published will be the verification displayed.
+
+Each verification is still generated behind the scenes though, and will work as expected when using 'can-i-deploy' in your build pipeline or via CLI.
+
+We are still working to improve aspects of the Bi-Directional contract UI, including the 'Matrix' view, which will offer a more complete display of each verification that is available.
+
+You can check our [roadmap](https://github.com/pactflow/roadmap/projects/1) for progress, or to vote for new items
+:::
+
 ## Bi-Directional Contract Testing Detail Page
 
 Bi-Directional Contract Testing detail page holds detailed schema comparison results between a provider contract versus a consumer contract (pact) along with metadata, participant information and provider self-verification results.
@@ -48,6 +59,15 @@ Note: When a classic pact test is performed along with Bi-Directional Contract T
 
 ### Provider Contract Tab
 Show provider contract detail and provider self verification result. Currently, only OpenAPI/Swagger is supported. 
+### Matrix View Tab
+
+Currently the matrix page will only show consumer generated contracts.
+
+Each verification is still generated behind the scenes though, and will work as expected when using 'can-i-deploy' in your build pipeline or via CLI.
+
+We are still working to improve aspects of the Bi-Directional contract UI, including this 'Matrix' view, which will offer a more complete display of each verification that is available.
+
+You can check our [roadmap](https://github.com/pactflow/roadmap/projects/1) for progress, or to vote for new items
 
 
 ## Contract Incompatibility Messages
@@ -66,13 +86,3 @@ When provider and consumer contracts are incompatible, incompatibility messages 
 | Response body contains unknown information | Pact response's body contains unknown content compared with provider contract|
 | Response request is incompatible | Pact response's request content is incompatible with provider contract|
 | Reponse header contains unknown information | Pact response's header contains unknown content compared with provider contract |
-
-:::info we are working hard to improve this view even further.
-Currently this page supports showing one verification per consumer version, whichever provider version was most recently published will be the verification displayed.
-
-Each verification is still generated behind the scenes though, and will work as expected when using 'can-i-deploy' in your build pipeline or via CLI.
-
-We are still working to improve aspects of the Bi-Directional contract UI, including the 'Matrix' view, which will offer a more complete display of each verification that is available.
-
-You can check our [roadmap](https://github.com/pactflow/roadmap/projects/1) for progress, or to vote for new items
-:::

--- a/website/docs/docs/user-interface/bi-directional.md
+++ b/website/docs/docs/user-interface/bi-directional.md
@@ -73,7 +73,7 @@ You can check our [roadmap](https://github.com/pactflow/roadmap/projects/1) for 
 ## Contract Incompatibility Messages
 When provider and consumer contracts are incompatible, incompatibility messages and mismatches are listed at [Contract Comparison Tab](#contract-comparison-tab). You can also find incompatibility messages under interaction items at [Consumer Contract Tab](#consumer-contract-tab)
 
-| Error Messsage | Description |
+| Error Message | Description |
 | ---------- | ----------- |
 | Request accept header is incompatible | Pact request's accept header content is incompatible with provider contract |
 | Request misses authorization header | Pact request's authorization header is missing |
@@ -85,4 +85,4 @@ When provider and consumer contracts are incompatible, incompatibility messages 
 | Response body is incompatible | Pact response's body content is incompatible with provider contract |
 | Response body contains unknown information | Pact response's body contains unknown content compared with provider contract|
 | Response request is incompatible | Pact response's request content is incompatible with provider contract|
-| Reponse header contains unknown information | Pact response's header contains unknown content compared with provider contract |
+| Response header contains unknown information | Pact response's header contains unknown content compared with provider contract |

--- a/website/docs/docs/user-interface/bi-directional.md
+++ b/website/docs/docs/user-interface/bi-directional.md
@@ -66,3 +66,13 @@ When provider and consumer contracts are incompatible, incompatibility messages 
 | Response body contains unknown information | Pact response's body contains unknown content compared with provider contract|
 | Response request is incompatible | Pact response's request content is incompatible with provider contract|
 | Reponse header contains unknown information | Pact response's header contains unknown content compared with provider contract |
+
+:::info we are working hard to improve this view even further.
+Currently this page supports showing one verification per consumer version, whichever provider version was most recently published will be the verification displayed.
+
+Each verification is still generated behind the scenes though, and will work as expected when using 'can-i-deploy' in your build pipeline or via CLI.
+
+We are still working to improve aspects of the Bi-Directional contract UI, including the 'Matrix' view, which will offer a more complete display of each verification that is available.
+
+You can check our [roadmap](https://github.com/pactflow/roadmap/projects/1) for progress, or to vote for new items
+:::

--- a/website/src/components/tabGenerator.js
+++ b/website/src/components/tabGenerator.js
@@ -85,7 +85,7 @@ function generateLanguageTab({ data, withLabel, withLink }) {
           key,
           content: (
             <a href={data[key].iconLink}>
-              {data[key].iconTitle} Implemenation Guide
+              {data[key].iconTitle} Implementation Guide
             </a>
           ), // for demo, need to add our own content
           withLabel,


### PR DESCRIPTION
As a heads up,

Our FAQ page on docs.pactflow.com isn't listed in the sidebar but does get indexed in the search.

We probably want to exclude pages that aren't ready yet, from being indexed.

It might be nice to start filling some of this information in

we have a load of info from the main site about the PF Feature Roadmap https://pactflow.io/pactflow-feature-roadmap/