### PR TITLE
fix: update link so it is relative to root

### DIFF
--- a/website/docs/docs/bi-directional-contract-testing/publishing.md
+++ b/website/docs/docs/bi-directional-contract-testing/publishing.md
@@ -5,5 +5,5 @@ sidebar_label: Publishing Contracts
 
 For details on publishing Pact files to Pactflow, see [Sharing Pacts with the Pact Broker](https://docs.pact.io/getting_started/sharing_pacts).
 
-For publishing OAS files, refer to [Publishing the Provider Contract + Results to Pactflow](contracts/oas#publishing-the-provider-contract--results-to-pactflow).
+For publishing OAS files, refer to [Publishing the Provider Contract + Results to Pactflow](/docs/bi-directional-contract-testing/contracts/oas#publishing-the-provider-contract--results-to-pactflow).
 


### PR DESCRIPTION
Fixes https://pact-foundation.slack.com/archives/CLS16AVEE/p1651660453175419

[Lei Shi](https://app.slack.com/team/U03DMAGHFL0)  [4 hours ago](https://pact-foundation.slack.com/archives/CLS16AVEE/p1651660453175419)

> Hi team. just trying the free version packflow.   the page link to how to publish contract is not accessible. https://docs.pactflow.io/docs/bi-directional-contract-testing/publishing/


Lei Shi  4 hours ago

> I mean https://docs.pactflow.io/docs/bi-directional-contract-testing/publishing/contracts/oas#publishing-the-provider-contract--results-to-pactflow

Matt (pactflow.io / pact-js / pact-go)  3 hours ago

> https://pactflow.io/pricing/

Matt (pactflow.io / pact-js / pact-go)  3 hours ago
That what you 

> wanted?

Yousaf Nabi (pactflow.io)  1 hour ago

> Hey @Lei Shi thanks for the report! I will get this addressed
> If the url has a trailing forward-slash, the redirect isn't working.
> The are getting the trailing forward-slash added to the URL when deeplinking to the page, or directly navigating to the url.
> 1. https://docs.pactflow.io/docs/bi-directional-contract-testing/publishing/
> 2. Click on Publishing the Provider Contract + Results to Pactflow.
> 3. takes us to https://docs.pactflow.io/docs/bi-directional-contract-testing/publishing/contracts/oas#publishing-the-provider-contract--results-to-pactflow


> This URL is shown, when we select publishing contracts from the side bar.
> 1. https://docs.pactflow.io/docs/bi-directional-contract-testing/publishing
> 2. [Publishing the Provider Contract + Results to Pactflow](https://docs.pactflow.io/docs/bi-directional-contract-testing/contracts/oas#publishing-the-provider-contract--results-to-pactflow).
> 3. takes us to https://docs.pactflow.io/docs/bi-directional-contract-testing/contracts/oas#publishing-the-provider-contract--results-to-pactflow
> The difference between the 2. The first link is being generated as relative, if the trailing forward-slashe is present, so it is trying to find it under /publishing... where it doesn't exist (edited)

