### PR TITLE
chore: update supported pact verification versions

### DIFF
--- a/website/docs/docs/bi-directional-contract-testing/contracts/pact.md
+++ b/website/docs/docs/bi-directional-contract-testing/contracts/pact.md
@@ -13,7 +13,7 @@ sidebar_label: Pact
 | 3       | ✅         |
 | 4+      | ❌         |
 
-*NOTE: On-Premises will support Pact Sspecification Version 3 from the next release: 1.19.0*
+*NOTE: On-Premises will support Pact Specification Version 3 from the next release: 1.19.0*
 
 ## Compatibility with Provider Contracts
 

--- a/website/docs/docs/bi-directional-contract-testing/contracts/pact.md
+++ b/website/docs/docs/bi-directional-contract-testing/contracts/pact.md
@@ -10,8 +10,10 @@ sidebar_label: Pact
 | 1       | ✅         |
 | 1.1     | ✅         |
 | 2       | ✅         |
-| 3       | ❌         |
+| 3       | ✅         |
 | 4+      | ❌         |
+
+*NOTE: On-Premises will support Pact Sspecification Version 3 from the next release: 1.19.0*
 
 ## Compatibility with Provider Contracts
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -75,7 +75,9 @@ module.exports = {
     tableOfContents: {
       maxHeadingLevel: 4,
     },
-    hideableSidebar: true,
+    docs: {
+      sidebar: { hideable: true },
+    },
     cleanUrl: true,
     trailingSlash: true,
     algolia: {

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -75,9 +75,7 @@ module.exports = {
     tableOfContents: {
       maxHeadingLevel: 4,
     },
-    docs: {
-      sidebar: { hideable: true },
-    },
+    hideableSidebar: true,
     cleanUrl: true,
     trailingSlash: true,
     algolia: {


### PR DESCRIPTION
* Update the compatibility section to show that pact spec V3 is now supported for BDCT, and note for when on-prem will support this