### PR TITLE
feat: pact broker migration docs PACT-158

### DIFF
--- a/website/docs/docs/getting-started.mdx
+++ b/website/docs/docs/getting-started.mdx
@@ -62,15 +62,15 @@ And, if you need Pactflow specific technical support, email support@pactflow.io 
 
 # Migrating from Pact Broker
 
-When you sign up with Pactflow we create a new hosted database for you. However if you have previously used the open source Pact Broker for your contract testing needs we can help migrate the data so that nothing is lost. The process involves moving your existing database to the hosted environment associated with your Pactflow account, then updating it for full compatibility with Pactflow.
+When you sign up to the SaaS Pactflow platform we create a new hosted database for you. However if you have previously used the open source Pact Broker for your contract testing needs we can help migrate the data so that nothing is lost. The process involves moving your existing database to the hosted environment associated with your Pactflow account, then updating it for full compatibility with Pactflow.
 This will require some scheduled down time for the service, including contract publishing and 'can-i-deploy' webhook.
 
 To get started with migrating from Pact Broker contact us at support@pactflow.io with the subject 'migrating from Pact Broker'.
 
-:::note
-note - applies to Saas (Hosted) Pactflow Brokers only.
+:::info
+Applies to SaaS (Hosted) Pactflow accounts only.
 
-Using On-Prem and want to migrate? Check out our on-prem migration guide [here](https://docs.pactflow.io/docs/on-premises/installation/migrating).
+Using On-Prem and want to migrate? Check out our on-prem migration guide [**here**](https://docs.pactflow.io/docs/on-premises/installation/migrating).
 :::
 
 ## Configuring your API token

--- a/website/docs/docs/getting-started.mdx
+++ b/website/docs/docs/getting-started.mdx
@@ -70,7 +70,7 @@ To get started with migrating from Pact Broker contact us at support@pactflow.io
 :::info
 Applies to SaaS (Hosted) Pactflow accounts only.
 
-Using On-Prem and want to migrate? Check out our on-prem migration guide [**here**](https://docs.pactflow.io/docs/on-premises/installation/migrating).
+Using On-Premises and want to migrate to the SaaS platform?? Check out our on-prem migration guide [**here**](/docs/on-premises/installation/migrating).
 :::
 
 ## Configuring your API token

--- a/website/docs/docs/getting-started.mdx
+++ b/website/docs/docs/getting-started.mdx
@@ -67,6 +67,12 @@ This will require some scheduled down time for the service, including contract p
 
 To get started with migrating from Pact Broker contact us at support@pactflow.io with the subject 'migrating from Pact Broker'.
 
+:::note
+note - applies to Saas (Hosted) Pactflow Brokers only.
+
+Using On-Prem and want to migrate? Check out our on-prem migration guide [here](https://docs.pactflow.io/docs/on-premises/installation/migrating).
+:::
+
 ## Configuring your API token
 
 **NOTE: You cannot use your username and password to access the Pactflow API.**

--- a/website/docs/docs/getting-started.mdx
+++ b/website/docs/docs/getting-started.mdx
@@ -60,6 +60,13 @@ We also have a Slack workspace where you can chat with other members and get gen
 
 And, if you need Pactflow specific technical support, email support@pactflow.io or for help with a PoC or plan options get in touch with sales.
 
+# Migrating from Pact Broker
+
+When you sign up with Pactflow we create a new hosted database for you. However if you have previously used the open source Pact Broker for your contract testing needs we can help migrate the data so that nothing is lost. The process involves moving your existing database to the hosted environment associated with your Pactflow account, then updating it for full compatibility with Pactflow.
+This will require some scheduled down time for the service, including contract publishing and 'can-i-deploy' webhook.
+
+To get started with migrating from Pact Broker contact us at support@pactflow.io with the subject 'migrating from Pact Broker'.
+
 ## Configuring your API token
 
 **NOTE: You cannot use your username and password to access the Pactflow API.**

--- a/website/docs/docs/on-premises/database.md
+++ b/website/docs/docs/on-premises/database.md
@@ -1,11 +1,11 @@
 ---
 title: Database
----
+---cd web   
 
 A PostgreSQL database is required for storage of the application data.
 
 :::info
- If you would like to migrate an existing PostgreSQL database, skip this section and instead follow the guide [**here**](https://docs.pactflow.io/docs/on-premises/installation/migrating).
+ If you would like to migrate an existing PostgreSQL database, skip this section and instead follow the guide [**here**](/docs/on-premises/installation/migrating).
 :::
 
 ## Supported versions

--- a/website/docs/docs/on-premises/database.md
+++ b/website/docs/docs/on-premises/database.md
@@ -4,6 +4,10 @@ title: Database
 
 A PostgreSQL database is required for storage of the application data.
 
+:::info
+ If you would like to migrate an existing PostgreSQL database, skip this section and instead follow the guide [**here**](https://docs.pactflow.io/docs/on-premises/installation/migrating).
+:::
+
 ## Supported versions
 
 PostgreSQL version 10.6 and later are supported.

--- a/website/docs/docs/on-premises/installation/migrating-from-pact-broker.md
+++ b/website/docs/docs/on-premises/installation/migrating-from-pact-broker.md
@@ -5,9 +5,13 @@ title: Migrating from Pact Broker
 
 # Migrating from Pact Broker
 
-If you have previously used the open source Pact Broker with a PostgreSQL database it is possible to migrate that data to Pactflow, keeping everything and making it available in Pactflow. The migration process uses the existing Pact Broker database, database migrations are then performed to add additional tables and data used for Pactflow features.
+If you have previously used the open source Pact Broker with a PostgreSQL database it is possible to migrate that data to Pactflow, keeping everything and making it available in Pactflow. The migration process uses the existing Pact Broker database. Database migrations are then performed to add additional tables and data used for Pactflow features.
 
 If there is no existing Pact Broker instance continue to the [Database](https://docs.pactflow.io/docs/on-premises/database) section.
+
+:::note
+Migration is only supported for a Pact Broker running a PostgreSQL database.
+:::
 
 ## Single Pact Broker instance
 
@@ -15,14 +19,14 @@ Follow existing [set up documentation](https://docs.pactflow.io/docs/on-premises
 
 1. Re-use your existing Pact Broker environment variables, updating the names to read `PACTFLOW_*` instead of `PACT_BROKER_*`. A full list of the Pactflow environment variables can be found [here](https://docs.pactflow.io/docs/on-premises/environment-variables).
 
-:::note
+:::tip
 
-It is crucial that all `PACTBROKER_DATABASE_*` environment variables are renamed to `PACTFLOW_DATABASE_*` while their `values` remain the same. This is because your existing Pact Broker database will be used, and updated for use with Pactflow as part of the process.
+It is crucial that all `PACT_BROKER_DATABASE_*` environment variables are renamed to `PACTFLOW_DATABASE_*` while their `values` remain the same. This is because your existing Pact Broker database will be used, and updated for use with Pactflow as part of the process.
 :::
 
+2. If you previously set the environment variables `PACT_BROKER_AUTO_MIGRATE_DB` and `PACT_BROKER_AUTO_MIGRATE_DB_DATA` remove these and replace them with a new environment variable named `PACTFLOW_DATABASE_AUTO_MIGRATE`. Set its value to `true`. This environment variable will allow your existing database to be updated with the required structures and data to support Pactflow, and maintain any existing data.  
+You do not need to add the new variable if you did not previously set `PACT_BROKER_AUTO_MIGRATE_DB` and `PACT_BROKER_AUTO_MIGRATE_DB_DATA`.
 
-2. Remove the environment variables called `PACT_BROKER_AUTO_MIGRATE_DB` and `PACT_BROKER_AUTO_MIGRATE_DB_DATA`
-3. Add a new environment variable to replace these called `PACTFLOW_DATABASE_AUTO_MIGRATE`, set its value to `true`. This environment variable will allow your existing database to be updated with the required structures and data to support Pactflow, and maintain any existing data.
 4. When the Pactflow instance starts up the migrations will run automatically. The migrations can be run manually instead if needed. See details [here](https://docs.pactflow.io/docs/on-premises/upgrading/database-migrations)
 
 ## Multiple Pact Broker instances
@@ -33,7 +37,7 @@ The recommended steps are as follows:
 
 1. Select one of the Pact Broker databases to update and use going forwards.
 2. Follow instructions above to set up Pactflow using this database.
-3. The Pact Broker instances that was used in the upgrade process and be decommissioned, as the database and it's contents are now available in Pactflow.
-4. Run the Pactflow instance and any other existing Pact Broker instances in parallel. You will need to update API calls such as publishing pacts and checking can-i-deploy to utilise both Pactflow and the old Pact Brokers. In this way all new data can gradually added to Pactflow while ensuring `can-i-deploy` still has access to production versions of all services.
-5. Continue to run Pactflow and Pact Brokers in parallel. Once the Pactflow instance contains all the `production` versions for all the services used in the contract tests the old Pact Broker instances can be safely decommissioned. This will allow Pactflow to be the soul source of data for 'can-i-deploy'
-6. Clean up any code and API calls that were used to run Pactflow and existing Pact Brokers in parallel.
+3. The Pact Broker instances that was used in the upgrade process and be decommissioned, as the database and its contents are now available in Pactflow.
+4. Run the Pactflow instance and any other existing Pact Broker instances in parallel. Duplicate the pact publication and pact verification tasks in your pipeline. The duplicated task should use the new Pactflow instance details. In this way all new data can gradually added to Pactflow while ensuring `can-i-deploy` still has access to production versions of all services.
+5. Continue to run Pactflow and Pact Brokers in parallel. Once the Pactflow instance contains all the `production` versions for all the services used in the contract tests the old Pact Broker instances can be safely decommissioned. This will allow Pactflow to be the sole source of data for 'can-i-deploy'
+6. Clean up any code and API calls that were used to run Pactflow and existing Pact Brokers in parallel. The pact publication and pact verification steps in your pipeline that used the old Pact Brokers can be removed.

--- a/website/docs/docs/on-premises/installation/migrating-from-pact-broker.md
+++ b/website/docs/docs/on-premises/installation/migrating-from-pact-broker.md
@@ -1,0 +1,34 @@
+---
+id: migrating
+title: Migrating from Pact Broker
+---
+
+# Migrating from Pact Broker
+
+It is possible to migrate from using the open source Pact Broker to Pactflow, keeping all existing data and making it available in Pactflow. The migration process uses the existing Pact Broker database, database migrations are then performed to add additional tables and data used for Pactflow features.
+
+If there is no existing Pact Broker instance continue to the [Database](https://docs.pactflow.io/docs/on-premises/database) section.
+
+## Single Pact Broker instance
+
+Follow existing [set up documentation](https://docs.pactflow.io/docs/on-premises) for setting up your new Pactflow, until the section titled ['Database'](https://docs.pactflow.io/docs/on-premises/database).
+
+To migrate your existing Pact Broker follow these steps instead of creating a new database:
+
+1. Re-use your existing Pact Broker environment variables, updating the names to read `PACTFLOW_` instead of `PACT_BROKER_`. It is crucial that the values for `DATABASE` related environment variables remain the same so that your Pact Broker database will be updated and used. A full list of the Pactflow environment variables can be found [here](https://docs.pactflow.io/docs/on-premises/environment-variables).
+2. Remove the environment variables called `PACT_BROKER_AUTO_MIGRATE_DB` and `PACT_BROKER_AUTO_MIGRATE_DB_DATA`
+3. Add a new environment variable to replace these called `PACTFLOW_DATABASE_AUTO_MIGRATE`, set its value to `true`. This environment variable will allow your existing database to be updated with the required structures and data to support Pactflow, and maintain any existing data.
+4. When the Pactflow instance starts up the migrations will run automatically. The migrations can be run manually instead if needed. See details [here](https://docs.pactflow.io/docs/on-premises/upgrading/database-migrations)
+
+## Multiple Pact Broker instances
+
+It is not currently possible to combine multiple Pact Broker databases into a single database for use with Pactflow. Instead one Pact Broker database can be used in the migration, and the others ran in parallel with the new Pactflow instance until sufficient data is transferred. The Pactflow instance must contain all production versions of all services used in the contract test before it can safely take over all 'can-i-deploy' checks.
+
+The recommended steps are as follows:
+
+1. Select one of the Pact Broker databases to update and use going forwards.
+2. Follow instructions above to set up Pactflow using this database.
+3. The Pact Broker instances that was used in the upgrade process and be decommissioned, as the database and it's contents are now available in Pactflow.
+4. Run the Pactflow instance and any other existing Pact Broker instances in parallel. You will need to update API calls such as publishing pacts and checking can-i-deploy to utilise both Pactflow and the old Pact Brokers. In this way all new data can gradually added to Pactflow while ensuring `can-i-deploy` still has access to production versions of all services.
+5. Continue to run Pactflow and Pact Brokers in parallel. Once the Pactflow instance contains all the `production` versions for all the services used in the contract tests the old Pact Broker instances can be safely decommissioned. This will allow Pactflow to be the soul source of data for 'can-i-deploy'
+6. Clean up any code and API calls that were used to run Pactflow and existing Pact Brokers in parallel.

--- a/website/docs/docs/on-premises/installation/migrating-from-pact-broker.md
+++ b/website/docs/docs/on-premises/installation/migrating-from-pact-broker.md
@@ -7,17 +7,15 @@ title: Migrating from Pact Broker
 
 If you have previously used the open source Pact Broker with a PostgreSQL database it is possible to migrate that data to Pactflow, keeping everything and making it available in Pactflow. The migration process uses the existing Pact Broker database. Database migrations are then performed to add additional tables and data used for Pactflow features.
 
-If there is no existing Pact Broker instance continue to the [Database](https://docs.pactflow.io/docs/on-premises/database) section.
-
 :::note
 Migration is only supported for a Pact Broker running a PostgreSQL database.
 :::
 
 ## Single Pact Broker instance
 
-Follow existing [set up documentation](https://docs.pactflow.io/docs/on-premises) for setting up your new Pactflow. When you reach the section regarding setting up a [Database](https://docs.pactflow.io/docs/on-premises/database) follow these steps to migrate instead of creating a new database:
+Follow existing [set up documentation](/docs/on-premises) for setting up your new Pactflow. When you reach the section regarding setting up a [Database](/docs/on-premises/database) follow these steps to migrate instead of creating a new database:
 
-1. Re-use your existing Pact Broker environment variables, updating the names to read `PACTFLOW_*` instead of `PACT_BROKER_*`. A full list of the Pactflow environment variables can be found [here](https://docs.pactflow.io/docs/on-premises/environment-variables).
+1. Re-use your existing Pact Broker environment variables, updating the names to read `PACTFLOW_*` instead of `PACT_BROKER_*`. A full list of the Pactflow environment variables can be found [here](/docs/on-premises/environment-variables).
 
 :::tip
 
@@ -27,7 +25,7 @@ It is crucial that all `PACT_BROKER_DATABASE_*` environment variables are rename
 2. If you previously set the environment variables `PACT_BROKER_AUTO_MIGRATE_DB` and `PACT_BROKER_AUTO_MIGRATE_DB_DATA` remove these and replace them with a new environment variable named `PACTFLOW_DATABASE_AUTO_MIGRATE`. Set its value to `true`. This environment variable will allow your existing database to be updated with the required structures and data to support Pactflow, and maintain any existing data.  
 You do not need to add the new variable if you did not previously set `PACT_BROKER_AUTO_MIGRATE_DB` and `PACT_BROKER_AUTO_MIGRATE_DB_DATA`.
 
-4. When the Pactflow instance starts up the migrations will run automatically. The migrations can be run manually instead if needed. See details [here](https://docs.pactflow.io/docs/on-premises/upgrading/database-migrations)
+4. When the Pactflow instance starts up the migrations will run automatically. The migrations can be run manually instead if needed. See details [here](/docs/on-premises/upgrading/database-migrations)
 
 ## Multiple Pact Broker instances
 

--- a/website/docs/docs/on-premises/installation/migrating-from-pact-broker.md
+++ b/website/docs/docs/on-premises/installation/migrating-from-pact-broker.md
@@ -5,17 +5,22 @@ title: Migrating from Pact Broker
 
 # Migrating from Pact Broker
 
-It is possible to migrate from using the open source Pact Broker to Pactflow, keeping all existing data and making it available in Pactflow. The migration process uses the existing Pact Broker database, database migrations are then performed to add additional tables and data used for Pactflow features.
+If you have previously used the open source Pact Broker with a PostgreSQL database it is possible to migrate that data to Pactflow, keeping everything and making it available in Pactflow. The migration process uses the existing Pact Broker database, database migrations are then performed to add additional tables and data used for Pactflow features.
 
 If there is no existing Pact Broker instance continue to the [Database](https://docs.pactflow.io/docs/on-premises/database) section.
 
 ## Single Pact Broker instance
 
-Follow existing [set up documentation](https://docs.pactflow.io/docs/on-premises) for setting up your new Pactflow, until the section titled ['Database'](https://docs.pactflow.io/docs/on-premises/database).
+Follow existing [set up documentation](https://docs.pactflow.io/docs/on-premises) for setting up your new Pactflow. When you reach the section regarding setting up a [Database](https://docs.pactflow.io/docs/on-premises/database) follow these steps to migrate instead of creating a new database:
 
-To migrate your existing Pact Broker follow these steps instead of creating a new database:
+1. Re-use your existing Pact Broker environment variables, updating the names to read `PACTFLOW_*` instead of `PACT_BROKER_*`. A full list of the Pactflow environment variables can be found [here](https://docs.pactflow.io/docs/on-premises/environment-variables).
 
-1. Re-use your existing Pact Broker environment variables, updating the names to read `PACTFLOW_` instead of `PACT_BROKER_`. It is crucial that the values for `DATABASE` related environment variables remain the same so that your Pact Broker database will be updated and used. A full list of the Pactflow environment variables can be found [here](https://docs.pactflow.io/docs/on-premises/environment-variables).
+:::note
+
+It is crucial that all `PACTBROKER_DATABASE_*` environment variables are renamed to `PACTFLOW_DATABASE_*` while their `values` remain the same. This is because your existing Pact Broker database will be used, and updated for use with Pactflow as part of the process.
+:::
+
+
 2. Remove the environment variables called `PACT_BROKER_AUTO_MIGRATE_DB` and `PACT_BROKER_AUTO_MIGRATE_DB_DATA`
 3. Add a new environment variable to replace these called `PACTFLOW_DATABASE_AUTO_MIGRATE`, set its value to `true`. This environment variable will allow your existing database to be updated with the required structures and data to support Pactflow, and maintain any existing data.
 4. When the Pactflow instance starts up the migrations will run automatically. The migrations can be run manually instead if needed. See details [here](https://docs.pactflow.io/docs/on-premises/upgrading/database-migrations)

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -249,6 +249,7 @@ module.exports = {
             "docs/on-premises/system-requirements",
             "docs/on-premises/docker-image-registry",
             "docs/on-premises/network-configuration",
+            "docs/on-premises/installation/migrating",
             "docs/on-premises/database",
             "docs/on-premises/logging",
             {


### PR DESCRIPTION
This PR adds a detailed section on how to migrate existing Pact Broker db for on-prem users. I have also added a brief overview of the process to the 'Getting Started' section for SAAS users, who will need to contact us to do this as part of their onboarding.

We will need to follow up with some process notes on how to do this for our own reference for SAAS users.

I'll also update the customer care team issue index to flag this with them, any tickets with this type of query will need to be assigned to us.