### PR TITLE
chore: update docs about keyword support PACT-235

### DIFF
--- a/website/docs/docs/bi-directional-contract-testing/contracts/keyword-support.md
+++ b/website/docs/docs/bi-directional-contract-testing/contracts/keyword-support.md
@@ -1,0 +1,98 @@
+---
+title: OAS Keyword Support
+sidebar_label: OAS Keyword Support
+---
+
+# Keyword Support for OAS Contracts
+
+OAS contracts may contain logical keywords `anyOf`, `allOf`, and `oneOf`, which are used to create a complex schema, or validate a value against multiple criteria. In Bi-Directional Contract Testing these keywords are currently partially supported.
+
+## allOf
+
+Because Pactflow sets `additionalProperties` to `false` on response bodies, `allOf` cannot be used to validate a response body against multiple schemas.
+See this [write up](https://bitbucket.org/atlassian/swagger-mock-validator/src/master/FAQ.md) on this specific issue. 
+
+## oneOf, anyOf
+There is limited support for the `anyOf` and `oneOf` keywords. To compare the anyOf or oneOf schema with a response body from a pact contract you must:
+
+- Ensure the `type` of the bodies match
+- If the type of the body is `object` the object's fields need to be marked as `required`. Fields not marked as required will not be considered in the comparison and will not cause the integration to fail. It is recommended to mark all fields that the consumer will use as `required` in the OAS schema used for Bi-Directional Contract Testing.
+- It is recommended to programmatically dereference and inline `$refs` in the OAS document uploaded to Pactflow, as they can cause issues when verifying `nullable` fields and nested `$refs` can not be accurately compared with a pact file. This can be accomplished using packages such as [json-schema-merge-allof](https://www.npmjs.com/package/json-schema-merge-allof) and [json-schema-resolve-allof](https://www.npmjs.com/package/json-schema-resolve-allof) (works for anyOf and oneOf as well.)
+
+
+### Example anyOf schema
+```
+ "schema": {
+    "anyOf": [
+        {
+            "type": "object",         // verified
+            "properties": {
+                "age": {
+                    "type": "integer"
+                },
+                "nickname": {         // not verified
+                    "type": "string"
+                }
+            },
+            "required": [
+                "age"                 // verified
+            ]
+        },
+        {
+            "type": "object",
+            "properties": {
+                "pet_type": {
+                    "type": "string",
+                    "enum": [
+                        "Cat",
+                        "Dog"
+                    ]
+                },
+                "hunts": {            // not verified
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "pet_type"          // verified
+            ]
+        }
+    ]
+}
+```
+
+### Example oneOf schema
+
+```
+  "schema": {
+    "oneOf": [
+      {
+        "type": "object",           // verified
+        "properties": {             // not verified
+          "hunts": {
+            "type": "boolean"
+          },
+          "age": {
+            "type": "integer"
+          }
+        }
+      },
+      {
+        "type": "object",            // verified
+        "properties": {             // not verified
+          "bark": {
+            "type": "boolean"
+          },
+          "breed": {
+            "type": "string",
+            "enum": [
+              "Dingo",
+              "Husky",
+              "Retriever",
+              "Shepherd"
+            ]
+          }
+        }
+      }
+    ]
+  }
+```

--- a/website/docs/docs/bi-directional-contract-testing/contracts/oas.md
+++ b/website/docs/docs/bi-directional-contract-testing/contracts/oas.md
@@ -522,6 +522,7 @@ When using OpenAPI Specifications as a Provider Contract, you should be aware of
 - The OAS must be a valid YAML or JSON file. Pactflow will pre-validate the document is parseable and error if they aren't valid.
 - OAS documents must not be split across multiple files. You should combine any documents together, using tools like [OpenAPI Merge](https://github.com/robertmassaioli/openapi-merge) or [speccy](https://www.npmjs.com/package/speccy).
 - YAML formatted OAS documents must not use [anchors](https://yaml.org/spec/1.2.2/#3222-anchors-and-aliases), due to the potential security issues (see [YAML bomb](https://en.wikipedia.org/wiki/Billion_laughs_attack) for more). If your auto-generated specs have anchors, you can pre-process them via tools like [spruce](https://github.com/geofffranks/spruce), that will expand them for you.
+- It is recommended to programmatically dereference and inline `$refs` in the OAS document uploaded to Pactflow, as they can cause issues when validating `nullable` fields and nested `$refs` can not be accurately compared with a pact file. This can be accomplished using packages such as [json-schema-merge-allof](https://www.npmjs.com/package/json-schema-merge-allof) and [json-schema-resolve-allof](https://www.npmjs.com/package/json-schema-resolve-allof)
 
 ### Testing
 
@@ -533,6 +534,86 @@ When using OpenAPI Specifications as a Provider Contract, you should be aware of
 
 ### `allOf` support and other logical keywords
 
-Because Pactflow sets `additionalProperties` to `false` to prevent false positives during validation, it means that the use of `allOf` is not supported.
-
+Because Pactflow sets `additionalProperties` to `false` on response bodies, `allOf` cannot be used to validate a response body against multiple schemas.
 See this [write up](https://bitbucket.org/atlassian/swagger-mock-validator/src/master/FAQ.md) on this specific issue.
+
+There is limited support for `anyOf` keyword. The body used in the pact request body needs to match both the `type` and any `required` fields to match one of the schemas listed in `anyOf`. Note additional properties are not validated at all, so the consumer could be requesting other fields not available from the provider. As such anything required by the consumer should be marked as required in the OAS. 
+
+```
+ "schema": {
+    "anyOf": [
+        {
+            "type": "object",         // validated
+            "properties": {
+                "age": {
+                    "type": "integer"
+                },
+                "nickname": {         // not validated
+                    "type": "string"
+                }
+            },
+            "required": [
+                "age"                 // validated
+            ]
+        },
+        {
+            "type": "object",
+            "properties": {
+                "pet_type": {
+                    "type": "string",
+                    "enum": [
+                        "Cat",
+                        "Dog"
+                    ]
+                },
+                "hunts": {            // not validated
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "pet_type"          // validated
+            ]
+        }
+    ]
+}
+```
+
+
+There is limited support for the `oneOf` keywords in bi-directional contract testing. The `type` of the response body will need to be matched with `oneOf` the response schemas in the OAS document. However if the `type` of the body is an `object` the properties on the object will not be validated.
+Therefore an OAS such as this would not be supported. Both of the schemas used in oneOf are objects. Both will match with any pact file body that is also an object regardless of the properties, rather than satisfying the intended `oneOf` condition.
+
+
+```
+  "schema": {
+    "oneOf": [
+      {
+        "type": "object",           // validated
+        "properties": {             // not validated
+          "hunts": {
+            "type": "boolean"
+          },
+          "age": {
+            "type": "integer"
+          }
+        }
+      },
+      {
+        "type": "object",            // validated
+        "properties": {             // not validated
+          "bark": {
+            "type": "boolean"
+          },
+          "breed": {
+            "type": "string",
+            "enum": [
+              "Dingo",
+              "Husky",
+              "Retriever",
+              "Shepherd"
+            ]
+          }
+        }
+      }
+    ]
+  }
+```

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -61,6 +61,7 @@ module.exports = {
               items: [
                 "docs/bi-directional-contract-testing/contracts/pact",
                 "docs/bi-directional-contract-testing/contracts/oas",
+                "docs/bi-directional-contract-testing/contracts/keyword-support"
               ],
             },
             {


### PR DESCRIPTION
This doc update is to add additional notes around keyword support and the nullable field issue which was recently brought up by a customer. These can be used by customers and devs when doing support to guide how and when these keywords are used.

In the future we would like to work on improving some of these limitations of the swagger-mock-validator.