### PR TITLE
fix: update docker build to work / hot reload

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM node:lts
 WORKDIR /app/website
 
 EXPOSE 3000 35729
-COPY ./docs /app/docs
 COPY ./website /app/website
 RUN yarn install
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - 3000:3000
       - 35729:35729
     volumes:
-      - ./docs:/app/docs
+      - ./website/docs:/app/website/docs
       - ./website/core:/app/website/core
       - ./website/i18n:/app/website/i18n
       - ./website/pages:/app/website/pages


### PR DESCRIPTION
The docker-compose build was running as the folder in the docker file doesn't exist.
Hot reloading working, but mounting the docs folders in the container 