### PR TITLE
chore: add SwaggerHub role to docs

### DIFF
--- a/website/docs/docs/permissions/predefined-roles.md
+++ b/website/docs/docs/permissions/predefined-roles.md
@@ -87,7 +87,7 @@ The permissions associated with the guest role may not be modified.
 
 ## SwaggerHub
 
-A user with the SwaggerHub role can be used to provide an api token for the SwaggerHub integration, allowing the SwaggerHub to verify published pacts against live Swagger docs.
+A user with the SwaggerHub role can be used to provide an API Token for the SwaggerHub integration, allowing SwaggerHub to verify published pacts against live Swagger docs.
 
 The permissions associated with the SwaggerHub role may not be modified.
 

--- a/website/docs/docs/permissions/predefined-roles.md
+++ b/website/docs/docs/permissions/predefined-roles.md
@@ -85,6 +85,17 @@ The permissions associated with the guest role may not be modified.
 
 - [`contract_data:read:*`](/docs/permissions#contract_dataread)
 
+## SwaggerHub
+
+A user with the SwaggerHub role can be used to provide an api token for the SwaggerHub integration, allowing the SwaggerHub to verify published pacts against live Swagger docs.
+
+The permissions associated with the SwaggerHub role may not be modified.
+
+#### Permissions
+
+- [`environment:read:*`](/docs/permissions#environmentread)
+- [`contract_data:read:*`](/docs/permissions#contract_dataread)
+
 ## Test Maintainer (deprecated)
 
 The Test Maintainer role has been replaced by the User role. The difference between the User and Test Maintainer roles is that the User role has team scoped permissions for Webhook and Secret management.


### PR DESCRIPTION
Update the docs to include the SwaggerHub role which will be used in the SwaggerHub integration.