### PR TITLE
Fix reference to C++ instead of .NET in Getting Started

### DIFF
--- a/website/docs/docs/getting-started.mdx
+++ b/website/docs/docs/getting-started.mdx
@@ -362,7 +362,7 @@ end
 ```
 
 </TabItem>
-<TabItem value="dotnet" label={languageIconsWithLabels.label_cplusplus}>
+<TabItem value="dotnet" label={languageIconsWithLabels.label_dotnet}>
 
 #### .NET
 


### PR DESCRIPTION
In the Providers examples, the .NET example use the "C++" name, instead of .NET