### PR TITLE
chore(ci): disable cron and push crawl search docs job

### DIFF
--- a/.github/workflows/crawl-site.yml
+++ b/.github/workflows/crawl-site.yml
@@ -1,9 +1,9 @@
 name: Crawl PactFlow docs
 
 on:
-  schedule:
-  - cron: "0 0 * * 0"
-  push:
+  # schedule:
+  # - cron: "0 0 * * 0"
+  # push:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
We are out of space in our Algolia plan and this job run on push is causing GH checks to fail unnecessarily for unrelated changes.

This disables it, albeit able to be triggered by workflow_dispatch if/when resolved